### PR TITLE
Allow non-static methods in class which do not use any 'this'

### DIFF
--- a/rules/nest.js
+++ b/rules/nest.js
@@ -7,5 +7,11 @@ module.exports = {
      * NestJS uses named export over default export
      */
     'import/prefer-default-export': 'off',
+
+    /**
+     * It's not appropriate for NestJS components to use static method
+     * whenever no 'this' are used.
+     */
+    'class-methods-use-this': ['off']
   },
 };


### PR DESCRIPTION
```typescript
@Injectable()
export class AppService {
  /* eslint emits an error on following instance method */
  getHello(): string {
    return 'Hello World!';
  }
}
```

NestJS app development sometimes creates non-static methods with no `this` keywords.