### PR TITLE
turn off no-underscore-dangle

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -9,5 +9,10 @@ module.exports = {
      * see https://www.npmjs.com/package/eslint-config-prettier#arrow-body-style-and-prefer-arrow-callback
      */
     'implicit-arrow-linebreak': ['off'],
+
+    /**
+     * Allow access to library internal values using "_".
+     */
+    'no-underscore-dangle': 'off',
   },
 };


### PR DESCRIPTION
Allow accessing internal values using `_`

```typescript
const userAgent = context.getArgByIndex<MetaData>(1)._internal_repr[ // error
  'user-agent'
];
```